### PR TITLE
add `(i)qct/dcosqi/dcosqf/dcosqb` interfaces for quarter wave data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build*
 *.a
 *.so
 *.x
+*.mod
+*.smod
 
 # API-doc
 API-doc/

--- a/API-doc-FORD-file.md
+++ b/API-doc-FORD-file.md
@@ -19,17 +19,17 @@ extra_mods: iso_fortran_env:https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fFORT
             iso_c_binding:https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fC_005fBINDING.html#ISO_005fC_005fBINDING
 print_creation_date: true
 creation_date: %Y-%m-%d %H:%M %z
-project_github: https://github.com/certik/fftpack
+project_github: https://github.com/fortran-lang/fftpack
 license: by-sa
 author: Paul N. Swarztrauber & fftpack contributors
-github: https://github.com/certik/fftpack
+github: https://github.com/fortran-lang/fftpack
 dbg: true
 parallel: 4
 ---
 
 [TOC]
 
-@warning This API documentation for the certik/fftpack v4.0.0 is a work in progress.
+@warning This API documentation for the fortran-lang/fftpack v4.0.0 is a work in progress.
 
 Fortran FFTPACK API Documentation
 =================================
@@ -39,14 +39,14 @@ The documentation for comment markup in source code, running [FORD] and the [FOR
 
 [FORD]: https://github.com/Fortran-FOSS-Programmers/ford#readme
 [FORD wiki]: https://github.com/Fortran-FOSS-Programmers/ford/wiki
-[FORD project file]: https://github.com/certik/fftpack/blob/master/API-doc-FORD-file.md
+[FORD project file]: https://github.com/fortran-lang/fftpack/blob/master/API-doc-FORD-file.md
 
 A package of fortran subprograms for the fast fourier transform of periodic and other symmetric sequences.
 
 ## Getting started
 ### Get the code
 ```bash
-git clone https://github.com/certik/fftpack.git
+git clone https://github.com/fortran-lang/fftpack.git
 cd fftpack
 ```
 
@@ -55,12 +55,13 @@ Fortran Package Manager (fpm) is a great package manager and build system for Fo
 You can build using provided `fpm.toml`:
 ```bash
 fpm build --flag "-O2"
-fpm test --flag "-O2" tstfft
+fpm test --flag "-O2" --list
+fpm test --flag "-O2" <test_name, see `fpm.toml` or list>
 ```
 To use `fftpack` within your `fpm` project, add the following to your `fpm.toml` file:
 ```toml
 [dependencies]
-fftpack = { git="https://github.com/certik/fftpack.git" }
+fftpack = { git="https://github.com/fortran-lang/fftpack.git" }
 ```
 
 ## Build with Make
@@ -70,5 +71,7 @@ make
 ```
 
 ## Links
-[netlib/dfftpack1.0(fftpack4.0)](http://www.netlib.org/fftpack/)
-
+[netlib/dfftpack1.0(fftpack4.0)](http://www.netlib.org/fftpack/)  
+[Documents of fft routines in GNU/gsl based on `netlib/fftpack`](https://www.gnu.org/software/gsl/doc/html/fft.html#)  
+[Documents of scipy.fftpack](https://docs.scipy.org/doc/scipy/reference/fftpack.html)
+[NACR/FFTPACK 5.1](https://www2.cisl.ucar.edu/resources/legacy/fft5)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A package of fortran subprograms for the fast fourier transform of periodic and 
 ## Getting started
 ### Get the code
 ```bash
-git clone https://github.com/certik/fftpack.git
+git clone https://github.com/fortran-lang/fftpack.git
 cd fftpack
 ```
 
@@ -19,7 +19,7 @@ fpm test --flag "-O2" <test_name, see `fpm.toml` or list>
 To use `fftpack` within your `fpm` project, add the following to your `fpm.toml` file:
 ```toml
 [dependencies]
-fftpack = { git="https://github.com/certik/fftpack.git" }
+fftpack = { git="https://github.com/fortran-lang/fftpack.git" }
 ```
 
 ## Build with Make
@@ -31,4 +31,5 @@ make
 ## Links
 [netlib/dfftpack1.0(fftpack4.0)](http://www.netlib.org/fftpack/)  
 [Documents of fft routines in GNU/gsl based on `netlib/fftpack`](https://www.gnu.org/software/gsl/doc/html/fft.html#)  
-[Documents of scipy.fftpack](https://docs.scipy.org/doc/scipy/reference/fftpack.html)
+[Documents of scipy.fftpack](https://docs.scipy.org/doc/scipy/reference/fftpack.html)  
+[NACR/FFTPACK 5.1](https://www2.cisl.ucar.edu/resources/legacy/fft5)  

--- a/fpm.toml
+++ b/fpm.toml
@@ -57,6 +57,21 @@ name = "fftpack_dzfft"
 source-dir = "test"
 main = "test_fftpack_dzfft.f90"
 
+[[test]]
+name = "fftpack_dcosq"
+source-dir = "test"
+main = "test_fftpack_dcosq.f90"
+
+[[test]]
+name = "fftpack_qct"
+source-dir = "test"
+main = "test_fftpack_qct.f90"
+
+[[test]]
+name = "fftpack_iqct"
+source-dir = "test"
+main = "test_fftpack_iqct.f90"
+
 # `fftpack` utility routines
 [[test]]
 name = "fftpack_fftshift"

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,9 @@ SRCF90 = \
 	fftpack_rfft.f90\
 	fftpack_irfft.f90\
 	fftpack_fftshift.f90\
-	fftpack_ifftshift.f90
+	fftpack_ifftshift.f90\
+	fftpack_qct.f90\
+	fftpack_iqct.f90
 
 OBJF := $(SRCF:.f=.o)
 OBJF90 := $(SRCF90:.f90=.o)
@@ -77,5 +79,7 @@ fftpack_fft.o: fftpack.o
 fftpack_ifft.o: fftpack.o
 fftpack_rfft.o: fftpack.o
 fftpack_irfft.o: fftpack.o
+fftpack_qct.o: fftpack.o
+fftpack_iqct.o: fftpack.o
 fftpack_fftshift.o: fftpack.o
 fftpack_ifftshift.o: fftpack.o

--- a/src/fftpack.f90
+++ b/src/fftpack.f90
@@ -13,6 +13,9 @@ module fftpack
 
     public :: dzffti, dzfftf, dzfftb
 
+    public :: dcosqi, dcosqf, dcosqb
+    public :: qct, iqct
+
     interface
 
         !> Version: experimental
@@ -115,6 +118,38 @@ module fftpack
             real(kind=dp), intent(in) :: wsave(*)
         end subroutine dzfftb
 
+        !> Version: experimental
+        !>
+        !> Initialize `dcosqf` and `dcosqb`.
+        !> ([Specification](../page/specs/fftpack.html#dcosqi))
+        pure subroutine dcosqi(n, wsave)
+            import dp
+            integer, intent(in) :: n
+            real(kind=dp), intent(out) :: wsave(*)
+        end subroutine dcosqi
+
+        !> Version: experimental
+        !>
+        !> Forward transform of quarter wave data.
+        !> ([Specification](../page/specs/fftpack.html#dcosqf))
+        pure subroutine dcosqf(n, x, wsave)
+            import dp
+            integer, intent(in) :: n
+            real(kind=dp), intent(inout) :: x(*)
+            real(kind=dp), intent(in) :: wsave(*)
+        end subroutine dcosqf
+
+        !> Version: experimental
+        !>
+        !> Unnormalized inverse of `dcosqf`.
+        !> ([Specification](../page/specs/fftpack.html#dcosqb))
+        pure subroutine dcosqb(n, x, wsave)
+            import dp
+            integer, intent(in) :: n
+            real(kind=dp), intent(inout) :: x(*)
+            real(kind=dp), intent(in) :: wsave(*)
+        end subroutine dcosqb
+
     end interface
 
     !> Version: experimental
@@ -164,6 +199,30 @@ module fftpack
             real(kind=dp), allocatable :: result(:)
         end function irfft_dp
     end interface irfft
+
+    !> Version: experimental
+    !>
+    !> Forward transform of quarter wave data.
+    !> ([Specifiction](../page/specs/fftpack.html#qct))
+    interface qct
+        pure module function qct_dp(x, n) result(result)
+            real(kind=dp), intent(in) :: x(:)
+            integer, intent(in), optional :: n
+            real(kind=dp), allocatable :: result(:)
+        end function qct_dp
+    end interface qct
+
+    !> Version: experimental
+    !>
+    !> Backward transform of quarter wave data.
+    !> ([Specifiction](../page/specs/fftpack.html#iqct))
+    interface iqct
+        pure module function iqct_dp(x, n) result(result)
+            real(kind=dp), intent(in) :: x(:)
+            integer, intent(in), optional :: n
+            real(kind=dp), allocatable :: result(:)
+        end function iqct_dp
+    end interface iqct
 
     !> Version: experimental
     !>

--- a/src/fftpack_iqct.f90
+++ b/src/fftpack_iqct.f90
@@ -1,0 +1,36 @@
+submodule(fftpack) fftpack_iqct
+
+contains
+
+    !> Backward transform of quarter wave data.
+    pure module function iqct_dp(x, n) result(result)
+        real(kind=dp), intent(in) :: x(:)
+        integer, intent(in), optional :: n
+        real(kind=dp), allocatable :: result(:)
+
+        integer :: lenseq, lensav, i
+        real(kind=dp), allocatable :: wsave(:)
+
+        if (present(n)) then
+            lenseq = n
+            if (lenseq <= size(x)) then
+                result = x(:lenseq)
+            else if (lenseq > size(x)) then
+                result = [x, (0.0_dp, i=1, lenseq - size(x))]
+            end if
+        else
+            lenseq = size(x)
+            result = x
+        end if
+
+        !> Initialize FFT
+        lensav = 3*lenseq + 15
+        allocate (wsave(lensav))
+        call dcosqi(lenseq, wsave)
+
+        !> Backward transformation
+        call dcosqb(lenseq, result, wsave)
+
+    end function iqct_dp
+
+end submodule fftpack_iqct

--- a/src/fftpack_qct.f90
+++ b/src/fftpack_qct.f90
@@ -1,0 +1,36 @@
+submodule(fftpack) fftpack_qct
+
+contains
+
+    !> Forward transform of quarter wave data.
+    pure module function qct_dp(x, n) result(result)
+        real(kind=dp), intent(in) :: x(:)
+        integer, intent(in), optional :: n
+        real(kind=dp), allocatable :: result(:)
+
+        integer :: lenseq, lensav, i
+        real(kind=dp), allocatable :: wsave(:)
+
+        if (present(n)) then
+            lenseq = n
+            if (lenseq <= size(x)) then
+                result = x(:lenseq)
+            else if (lenseq > size(x)) then
+                result = [x, (0.0_dp, i=1, lenseq - size(x))]
+            end if
+        else
+            lenseq = size(x)
+            result = x
+        end if
+
+        !> Initialize FFT
+        lensav = 3*lenseq + 15
+        allocate (wsave(lensav))
+        call dcosqi(lenseq, wsave)
+
+        !> Forward transformation
+        call dcosqf(lenseq, result, wsave)
+
+    end function qct_dp
+
+end submodule fftpack_qct

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,10 +1,14 @@
-all: tstfft\
-fftpack_fft\
-fftpack_ifft\
-fftpack_rfft\
-fftpack_irfft\
-fftpack_fftshift\
-fftpack_ifftshift
+all: tstfft \
+	fftpack_fft \
+	fftpack_ifft \
+	fftpack_rfft \
+	fftpack_irfft \
+	fftpack_fftshift \
+	fftpack_ifftshift \
+	fftpack_dzfft \
+	fftpack_dcosq \
+	fftpack_qct \
+	fftpack_iqct
 
 # Orginal test
 tstfft: tstfft.o
@@ -27,6 +31,22 @@ fftpack_rfft: test_fftpack_rfft.f90
 fftpack_irfft: test_fftpack_irfft.f90
 	$(FC) $(FFLAGS) $< -L../src -l$(LIB) -I../src -o $@.x
 	./fftpack_irfft.x
+
+fftpack_dzfft: test_fftpack_dzfft.f90
+	$(FC) $(FFLAGS) $< -L../src -l$(LIB) -I../src -o $@.x
+	./fftpack_dzfft.x
+
+fftpack_dcosq: test_fftpack_dcosq.f90
+	$(FC) $(FFLAGS) $< -L../src -l$(LIB) -I../src -o $@.x
+	./fftpack_dcosq.x
+
+fftpack_qct: test_fftpack_qct.f90
+	$(FC) $(FFLAGS) $< -L../src -l$(LIB) -I../src -o $@.x
+	./fftpack_qct.x
+
+fftpack_iqct: test_fftpack_iqct.f90
+	$(FC) $(FFLAGS) $< -L../src -l$(LIB) -I../src -o $@.x
+	./fftpack_iqct.x
 
 # `fftpack` utility routines
 fftpack_fftshift: test_fftpack_fftshift.f90

--- a/test/test_fftpack_dcosq.f90
+++ b/test/test_fftpack_dcosq.f90
@@ -16,13 +16,14 @@ contains
         use iso_fortran_env, only: dp => real64
         real(kind=dp) :: w(3*4 + 15)
         real(kind=dp) :: x(4) = [1, 2, 3, 4]
+        real(kind=dp) :: eps = 1.0e-10_dp
 
         call dcosqi(4, w)
         call dcosqf(4, x, w)
         call check(sum(abs(x - [11.999626276085150_dp, -9.1029432177492193_dp, &
-                                2.6176618435106480_dp, -1.5143449018465791_dp])) < 1.0e-3, msg="`dcosqf` failed.")
+                                2.6176618435106480_dp, -1.5143449018465791_dp])) < eps, msg="`dcosqf` failed.")
         call dcosqb(4, x, w)    !!
-        call check(sum(abs(x/(4.0_dp*4.0_dp) - [real(kind=dp) :: 1, 2, 3, 4])) < 1.0e-3, msg="`dcosqb` failed.")
+        call check(sum(abs(x/(4.0_dp*4.0_dp) - [real(kind=dp) :: 1, 2, 3, 4])) < eps, msg="`dcosqb` failed.")
 
     end subroutine test_fftpack_dcosq_real
 

--- a/test/test_fftpack_dcosq.f90
+++ b/test/test_fftpack_dcosq.f90
@@ -1,0 +1,29 @@
+program tester
+
+    call test_fftpack_dcosq_real
+    print *, "All tests in `test_fftpack_dcosq` passed."
+
+contains
+
+    subroutine check(condition, msg)
+        logical, intent(in) :: condition
+        character(*), intent(in) :: msg
+        if (.not. condition) error stop msg
+    end subroutine check
+
+    subroutine test_fftpack_dcosq_real
+        use fftpack, only: dcosqi, dcosqf, dcosqb
+        use iso_fortran_env, only: dp => real64
+        real(kind=dp) :: w(3*4 + 15)
+        real(kind=dp) :: x(4) = [1, 2, 3, 4]
+
+        call dcosqi(4, w)
+        call dcosqf(4, x, w)
+        call check(sum(abs(x - [11.999626276085150_dp, -9.1029432177492193_dp, &
+                                2.6176618435106480_dp, -1.5143449018465791_dp])) < 1.0e-3, msg="`dcosqf` failed.")
+        call dcosqb(4, x, w)    !!
+        call check(sum(abs(x/(4.0_dp*4.0_dp) - [real(kind=dp) :: 1, 2, 3, 4])) < 1.0e-3, msg="`dcosqb` failed.")
+
+    end subroutine test_fftpack_dcosq_real
+
+end program tester

--- a/test/test_fftpack_dfft.f90
+++ b/test/test_fftpack_dfft.f90
@@ -23,11 +23,11 @@ contains
         call dffti(4, w)
         call dfftf(4, x, w)
         call check(all(x == [real(kind=dp) :: 10, -2, 2, -2]), &
-                   msg="all(x == [real(kind=dp) :: 10, -2, 2, -2]) failed.")
+                   msg="`dfftf` failed.")
 
         call dfftb(4, x, w)
         call check(all(x/4.0_dp == [real(kind=dp) :: 1, 2, 3, 4]), &
-                   msg="all(x/4.0_dp == [real(kind=dp) :: 1, 2, 3, 4]) failed.")
+                   msg="`dfftb` failed.")
 
     end subroutine test_fftpack_dfft
 

--- a/test/test_fftpack_dzfft.f90
+++ b/test/test_fftpack_dzfft.f90
@@ -22,9 +22,9 @@ contains
         call dzffti(4, w)
         call dzfftf(4, x, azero, a, b, w)
         call check(azero == 2.5_dp, msg="azero == 2.5_dp failed.")
-        call check(all(a == [real(kind=dp) :: -1.0, -0.5]), msg="all(a == [real(kind=dp) :: -1.0, -0.5]) failed.")
-        call check(all(b == [real(kind=dp) :: -1.0, 0.0]), msg="all(b == [real(kind=dp) :: -1.0, 0.0]) failed.")
-        
+        call check(all(a == [-1.0_dp, -0.5_dp]), msg="all(a == [-1.0, -0.5]) failed.")
+        call check(all(b == [-1.0_dp, 0.0_dp]), msg="all(b == [-1.0, 0.0]) failed.")
+
         x = 0
         call dzfftb(4, x, azero, a, b, w)
         call check(all(x == [real(kind=dp) :: 1, 2, 3, 4]), msg="all(x = [real(kind=dp) :: 1, 2, 3, 4]) failed.")

--- a/test/test_fftpack_fft.f90
+++ b/test/test_fftpack_fft.f90
@@ -14,18 +14,16 @@ contains
     subroutine test_fftpack_fft
         use fftpack, only: fft
         use iso_fortran_env, only: dp => real64
-        real(kind=dp) :: eps = 1.0e-10
+        real(kind=dp) :: eps = 1.0e-10_dp
 
-        complex(kind=dp) :: x(3)
+        complex(kind=dp) :: x(3) = [1.0_dp, 2.0_dp, 3.0_dp]
 
-        x = [real(kind=dp) :: 1.0, 2.0, 3.0]
-
-        call check(sum(abs(fft(x, 2) - [complex(kind=dp) ::(3.0, 0.0), (-1.0, 0.0)])) < eps, &
-                   msg="sum(abs(fft(x,2) - [complex(kind=dp) ::(3.0, 0.0), (-1.0, 0.0)])) < eps failed.")
+        call check(sum(abs(fft(x, 2) - [(3.0_dp, 0.0_dp), (-1.0_dp, 0.0_dp)])) < eps, &
+                   msg="`fft(x, 2)` failed.")
         call check(sum(abs(fft(x, 3) - fft(x))) < eps, &
-                   msg="sum(abs(fft(x,3) - fft(3))) < eps failed.")
-        call check(sum(abs(fft(x, 4) - [complex(kind=dp) ::(6.0, 0.0), (-2.0, -2.0), (2.0, 0.0), (-2.0, 2.0)])) < eps, &
-                   msg="sum(abs(fft(x,4) - [complex(kind=dp) ::(6.0, 0.0), (-2.0, -2.0), (2.0,0.0), (-2.0,2.0)])) < eps failed.")
+                   msg="`fft(x, 3)` failed.")
+        call check(sum(abs(fft(x, 4) - [(6.0_dp, 0.0_dp), (-2.0_dp, -2.0_dp), (2.0_dp, 0.0_dp), (-2.0_dp, 2.0_dp)])) < eps, &
+                   msg="`fft(x, 4)` failed.")
 
     end subroutine test_fftpack_fft
 

--- a/test/test_fftpack_ifft.f90
+++ b/test/test_fftpack_ifft.f90
@@ -14,18 +14,16 @@ contains
     subroutine test_fftpack_ifft
         use fftpack, only: fft, ifft
         use iso_fortran_env, only: dp => real64
-        real(kind=dp) :: eps = 1.0e-10
+        real(kind=dp) :: eps = 1.0e-10_dp
 
-        complex(kind=dp) :: x(4)
+        complex(kind=dp) :: x(4) = [1, 2, 3, 4]
 
-        x = [real(kind=dp) :: 1.0, 2.0, 3.0, 4.0]
-        
-        call check(sum(abs(ifft(fft(x))/4.0 - [complex(kind=dp) ::(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (4.0, 0.0)])) < eps, &
-        msg="abs(sum(ifft(fft(x))/4.0 - [complex(kind=dp) ::(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (4.0, 0.0)])) < eps failed.")
-        call check(sum(abs(ifft(fft(x),2) - [complex(kind=dp) ::(8.0, 2.0), (12.0, -2.0)])) < eps, &
-                   msg="abs(sum(ifft(fft(x),2) - [complex(kind=dp) ::(8.0, 2.0), (12.0, -2.0)])) < eps failed.")
-        call check(sum(abs(ifft(fft(x,2),4) - [complex(kind=dp) ::(2.0, 0.0), (3.0, -1.0), (4.0,0.0), (3.0,1.0)])) < eps, &
-        msg="abs(sum(ifft(fft(x,2),4) - [complex(kind=dp) ::(2.0, 0.0), (3.0, -1.0), (4.0,0.0), (3.0,1.0)])) < eps failed.")
+        call check(sum(abs(ifft(fft(x))/4.0_dp - [complex(kind=dp) :: 1, 2, 3, 4])) < eps, &
+                   msg="`ifft(fft(x))/4.0_dp` failed.")
+        call check(sum(abs(ifft(fft(x), 2) - [complex(kind=dp) ::(8, 2), (12, -2)])) < eps, &
+                   msg="`ifft(fft(x), 2)` failed.")
+        call check(sum(abs(ifft(fft(x, 2), 4) - [complex(kind=dp) ::(2, 0), (3, -1), (4, 0), (3, 1)])) < eps, &
+                   msg="`ifft(fft(x, 2), 4)` failed.")
 
     end subroutine test_fftpack_ifft
 

--- a/test/test_fftpack_iqct.f90
+++ b/test/test_fftpack_iqct.f90
@@ -14,7 +14,7 @@ contains
     subroutine test_fftpack_iqct
         use fftpack, only: qct, iqct
         use iso_fortran_env, only: dp => real64
-        real(kind=dp) :: eps = 1.0e-10
+        real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(4) = [1, 2, 3, 4]
 

--- a/test/test_fftpack_iqct.f90
+++ b/test/test_fftpack_iqct.f90
@@ -1,0 +1,31 @@
+program tester
+
+    call test_fftpack_iqct()
+    print *, "All tests in `test_fftpack_iqct` passed."
+
+contains
+
+    subroutine check(condition, msg)
+        logical, intent(in) :: condition
+        character(*), intent(in) :: msg
+        if (.not. condition) error stop msg
+    end subroutine check
+
+    subroutine test_fftpack_iqct
+        use fftpack, only: qct, iqct
+        use iso_fortran_env, only: dp => real64
+        real(kind=dp) :: eps = 1.0e-10
+
+        real(kind=dp) :: x(4) = [1, 2, 3, 4]
+
+        call check(sum(abs(iqct(qct(x))/(4.0_dp*4.0_dp) - [real(kind=dp) :: 1, 2, 3, 4])) < eps, &
+                   msg="`iqct(qct(x)/(4.0_dp*4.0_dp)` failed.")
+        call check(sum(abs(iqct(qct(x), 2)/(4.0_dp*2.0_dp) - [1.4483415291679655_dp, 7.4608849947753271_dp])) < eps, &
+                   msg="`iqct(qct(x), 2)/(4.0_dp*2.0_dp)` failed.")
+        call check(sum(abs(iqct(qct(x, 2), 4)/(4.0_dp*4.0_dp) - [0.5_dp, 0.70932417358418376_dp, 1.0_dp, &
+                                                                 0.78858050747473762_dp])) < eps, &
+                   msg="`iqct(qct(x, 2), 4)/(4.0_dp*4.0_dp)` failed.")
+
+    end subroutine test_fftpack_iqct
+
+end program tester

--- a/test/test_fftpack_irfft.f90
+++ b/test/test_fftpack_irfft.f90
@@ -14,16 +14,16 @@ contains
     subroutine test_fftpack_irfft
         use fftpack, only: rfft, irfft
         use iso_fortran_env, only: dp => real64
-        real(kind=dp) :: eps = 1.0e-10
+        real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(4) = [1, 2, 3, 4]
 
-        call check(sum(abs(irfft(rfft(x))/4.0 - [real(kind=dp) :: 1, 2, 3, 4])) < eps, &
-                   msg="sum(abs(irfft(rfft(x))/4.0 - [real(kind=dp) :: 1, 2, 3, 4])) < eps failed.")
+        call check(sum(abs(irfft(rfft(x))/4.0_dp - [real(kind=dp) :: 1, 2, 3, 4])) < eps, &
+                   msg="`irfft(rfft(x))/4.0_dp` failed.")
         call check(sum(abs(irfft(rfft(x), 2) - [real(kind=dp) :: 8, 12])) < eps, &
-                   msg="sum(abs(irfft(rfft(x), 2) - [real(kind=dp) :: 8, 12])) < eps failed.")
+                   msg="`irfft(rfft(x), 2)` failed.")
         call check(sum(abs(irfft(rfft(x, 2), 4) - [real(kind=dp) :: 1, 3, 5, 3])) < eps, &
-                   msg="sum(abs(irfft(rfft(x, 2), 4) - [real(kind=dp) :: 1, 3, 5, 3])) failed.")
+                   msg="`irfft(rfft(x, 2), 4)` failed.")
 
     end subroutine test_fftpack_irfft
 

--- a/test/test_fftpack_qct.f90
+++ b/test/test_fftpack_qct.f90
@@ -14,7 +14,7 @@ contains
     subroutine test_fftpack_qct
         use fftpack, only: qct
         use iso_fortran_env, only: dp => real64
-        real(kind=dp) :: eps = 1.0e-10
+        real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(3) = [9, -9, 3]
 

--- a/test/test_fftpack_qct.f90
+++ b/test/test_fftpack_qct.f90
@@ -1,0 +1,31 @@
+program tester
+
+    call test_fftpack_qct()
+    print *, "All tests in `test_fftpack_qct` passed."
+
+contains
+
+    subroutine check(condition, msg)
+        logical, intent(in) :: condition
+        character(*), intent(in) :: msg
+        if (.not. condition) error stop msg
+    end subroutine check
+
+    subroutine test_fftpack_qct
+        use fftpack, only: qct
+        use iso_fortran_env, only: dp => real64
+        real(kind=dp) :: eps = 1.0e-10
+
+        real(kind=dp) :: x(3) = [9, -9, 3]
+
+        call check(sum(abs(qct(x, 2) - [-3.7279220613578570_dp, 21.727922061357859_dp])) < eps, &
+                   msg="`qct(x, 2)` failed.")
+        call check(sum(abs(qct(x, 3) - qct(x))) < eps, &
+                   msg="`qct(x,3)` failed.")
+        call check(sum(abs(qct(x, 4) - [-3.3871908980838743_dp, -2.1309424696909023_dp, &
+                                        11.645661095452331_dp, 29.872472272322447_dp])) < eps, &
+                   msg="`qct(x, 4)` failed.")
+
+    end subroutine test_fftpack_qct
+
+end program tester

--- a/test/test_fftpack_rfft.f90
+++ b/test/test_fftpack_rfft.f90
@@ -14,16 +14,16 @@ contains
     subroutine test_fftpack_rfft
         use fftpack, only: rfft
         use iso_fortran_env, only: dp => real64
-        real(kind=dp) :: eps = 1.0e-10
+        real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(3) = [9, -9, 3]
 
         call check(sum(abs(rfft(x, 2) - [real(kind=dp) :: 0, 18])) < eps, &
-                   msg="sum(abs(rfft(x,2) - [real(kind=dp) :: 0, 18])) < eps failed.")
+                   msg="`rfft(x, 2)` failed.")
         call check(sum(abs(rfft(x, 3) - rfft(x))) < eps, &
-                   msg="sum(abs(rfft(x,3) - rfft(3))) < eps failed.")
+                   msg="`rfft(x, 3)` failed.")
         call check(sum(abs(rfft(x, 4) - [real(kind=dp) :: 3, 6, 9, 21])) < eps, &
-                   msg="sum(abs(rfft(x,4) - [real(kind=dp) ::3, 6, 9, 21])) < eps failed.")
+                   msg="`rfft(x, 4)` failed.")
 
     end subroutine test_fftpack_rfft
 

--- a/test/test_fftpack_zfft.f90
+++ b/test/test_fftpack_zfft.f90
@@ -15,18 +15,17 @@ contains
         use fftpack, only: zffti, zfftf, zfftb
         use iso_fortran_env, only: dp => real64
 
-        complex(kind=dp) :: x(4)
+        complex(kind=dp) :: x(4) = [1, 2, 3, 4]
         real(kind=dp) :: w(31)
 
-        x = [real(kind=dp) :: 1.0, 2.0, 3.0, 4.0]
         call zffti(4, w)
         call zfftf(4, x, w)
-        call check(all(x == [complex(kind=dp) ::(10.0, 0.0), (-2.0, 2.0), (-2.0, 0.0), (-2.0, -2.0)]), &
-                   msg="all(x==[complex(kind=dp) :: (10.0,0.0), (-2.0,2.0), (-2.0,0.0), (-2.0,-2.0)]) failed.")
+        call check(all(x == [complex(kind=dp) ::(10, 0), (-2, 2), (-2, 0), (-2, -2)]), &
+                   msg="`zfftf` failed.")
 
         call zfftb(4, x, w)
-        call check(all(x/4.0_dp == [complex(kind=dp) ::(1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (4.0, 0.0)]), &
-                   msg="all(x/4==[complex(kind=dp) :: (1.0,0.0), (2.0,0.0), (3.0,0.0), (4.0,0.0)]) failed.")
+        call check(all(x/4.0_dp == [complex(kind=dp) ::(1, 0), (2, 0), (3, 0), (4, 0)]), &
+                   msg="`zfftb` failed.")
 
     end subroutine test_fftpack_zfft
 


### PR DESCRIPTION
- [x] Add `(i)qct/dcosqi/dcosqf/dcosqb` interfaces
- [x] Repo link modification: `certik/fftpack` -> `fortran-lang/fftpack`

#### Description
Add interfaces of routines that computes the fast fourier transform of quarter wave data.


#### Notes
API-name `(i)qct` discussion, see #9 .
Later, I will improve `(i)dct` interfaces for `dcosti/dcost` routines.