### PR TITLE
add `(i)dct/dcosti/dcost` interfaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # FFTPACK
+
+[![Actions Status](https://github.com/fortran-lang/fftpack/workflows/fpm/badge.svg)](https://github.com/fortran-lang/fftpack/actions)
+
 A package of fortran subprograms for the fast fourier transform of periodic and other symmetric sequences.
 
 ## Getting started

--- a/doc/specs/fftpack.md
+++ b/doc/specs/fftpack.md
@@ -21,7 +21,7 @@ Experimental.
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -73,7 +73,7 @@ Experimental.
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -143,7 +143,7 @@ Experimental.
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -296,7 +296,7 @@ Experimental.
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -346,7 +346,7 @@ Experimental.
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -428,7 +428,7 @@ Experimental.
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -638,7 +638,7 @@ Experimental
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -712,7 +712,7 @@ Experimental
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -824,7 +824,7 @@ Experimental
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -873,7 +873,7 @@ Experimental
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -943,7 +943,7 @@ Experimental
 
 #### Class
 
-Pure function.
+Pure subroutine.
 
 #### Syntax
 
@@ -1086,6 +1086,216 @@ program demo_iqct
     print *, iqct(qct(x), 3)/(4.0*3.0)      !! [1.84, 2.71, 5.47]
 end program demo_iqct
 ```
+
+## Cosine transform of a real even sequence
+
+### `dcosti`
+
+#### Description
+
+Initializes the array `wsave` which is used in subroutine `dcost`. 
+The prime factorization of `n` together with a tabulation of the trigonometric functions are computed and stored in `wsave`.
+
+#### Status
+
+Experimental
+
+#### Class
+
+Pure subroutine.
+
+#### Syntax
+
+`call [[fftpack(module):dcosti(interface)]](n , wsave)`
+
+#### Arguments
+
+`n`: Shall be a `integer` scalar.
+This argument is `intent(in)`.  
+The length of the sequence to be transformed.  
+The method is most efficient when n-1 is a product of small primes.
+
+`wsave`: Shall be a `real` and rank-1 array.
+This argument is `intent(out)`.  
+A work array which must be dimensioned at least `3*n+15`. 
+Different `wsave` arrays are required for different values of `n`. 
+The contents of `wsave` must not be changed between calls of `dcost`.
+
+#### Example
+
+```fortran
+program demo_dcosti
+    use fftpack, only: dcosti
+    real(kind=8) :: w(3*4 + 15)
+    call dcosti(4, w)   !! Initializes the array `w` which is used in subroutine `dcost`. 
+end program demo_dcosti
+```
+
+### `dcost`
+
+#### Description
+
+Computes the discrete fourier cosine transform of an even sequence `x(i)`. 
+The transform is defined below at output parameter `x`.
+
+`dcost` is the unnormalized inverse of itself since a call of `dcost` followed by another call of `dcost` will multiply the input sequence `x` by `2*(n-1)`. 
+The transform is defined below at output parameter `x`.
+
+The array `wsave` which is used by subroutine `dcost` must be initialized by calling subroutine `dcosti(n,wsave)`.
+
+#### Status
+
+Experimental
+
+#### Class
+
+Pure subroutine.
+
+#### Syntax
+
+`call [[fftpack(module):dcost(interface)]](n, x, wsave)`
+
+#### Arguments
+
+`n`: Shall be a `integer` scalar.
+This argument is `intent(in)`.  
+The length of the sequence `x`. 
+`n` must be greater than `1`.
+The method is most efficient when `n-1` is a product of small primes.
+
+`x`: Shall be a `real` and rank-1 array.
+This argument is `intent(inout)`.
+An array which contains the sequence to be transformed.
+```
+for i=1,...,n
+
+    x(i) = x(1)+(-1)**(i-1)*x(n)
+
+        + the sum from k=2 to k=n-1
+
+            2*x(k)*cos((k-1)*(i-1)*pi/(n-1))
+
+        a call of dcost followed by another call of
+        dcost will multiply the sequence x by 2*(n-1)
+        hence dcost is the unnormalized inverse
+        of itself.
+```
+
+`wsave`: Shall be a `real` and rank-1 array.
+This argument is `intent(in)`.  
+A work array which must be dimensioned at least `3*n+15` in the program that calls `dcost`. 
+The `wsave` array must be initialized by calling subroutine `dcosti(n,wsave)` and a different `wsave` array must be used for each different value of `n`. 
+This initialization does not have to be repeated so long as `n` remains unchanged thus subsequent
+transforms can be obtained faster than the first.
+Contains initialization calculations which must not be destroyed between calls of `dcost`.
+
+#### Example
+
+```fortran
+program demo_dcost
+    use fftpack, only: dcosti, dcost
+    real(kind=8) :: x(4) = [1, 2, 3, 4]
+    real(kind=8) :: w(3*4 + 15)
+    call dcosti(4, w)
+    call dcost(4, x, w)     !! Computes the discrete fourier cosine (forward) transform of an even sequence, `x`(unnormalized): [15.0, -4.0, 0.0, -1.0]
+    call dcost(4, x, w)     !! Computes the discrete fourier cosine (backward) transform of an even sequence, `x`(unnormalized): [6.0, 12.0, 18.0, 24.0]
+end program demo_dcost
+```
+
+### `dct`
+
+#### Description
+
+Discrete fourier cosine (forward) transform of an even sequence. 
+
+#### Status
+
+Experimental.
+
+#### Class
+
+Pure function.
+
+#### Syntax
+
+`result = [[fftpack(module):dct(interface)]](x [, n])`
+
+#### Argument
+
+`x`: Shall be a `real` and rank-1 array.
+This argument is `intent(in)`.  
+The data to transform.
+
+`n`: Shall be an `integer` scalar.
+This argument is `intent(in)` and `optional`.  
+Defines the length of the Fourier transform. If `n` is not specified (the default) then `n = size(x)`. If `n <= size(x)`, `x` is truncated, if `n > size(x)`, `x` is zero-padded.
+
+#### Return value
+
+Returns a `real` and rank-1 array, the Discrete-Cosine Transform (DCT) of `x`.
+
+#### Notes
+
+Within numerical accuracy, `y == dct(idct(y))/2*(size(y) - 1)`.
+
+#### Example
+
+```fortran
+program demo_dct
+    use fftpack, only: dct
+    real(kind=8) :: x(4) = [1, 2, 3, 4]
+    print *, dct(x,3)      !! [8.0, -2.0, 0.0].
+    print *, dct(x)        !! [15.0, -4.0, 0.0, -1.0].
+    print *, dct(x,5)      !! [19.0, -1.8, -5.0, 3.8, -5.0].
+    print *, dct(dct(x))/(2*(4 - 1))   !! (normalized): [1.0, 2.0, 3.0, 4.0]
+end program demo_dct
+```
+
+### `idct`
+
+#### Description
+
+Unnormalized inverse of `dct`.
+In fact, `idct` and `dct` have the same effect, `idct` = `dct`.
+
+#### Status
+
+Experimental.
+
+#### Class
+
+Pure function.
+
+#### Syntax
+
+`result = [[fftpack(module):idct(interface)]](x [, n])`
+
+#### Argument
+
+`x`: Shall be a `real` array.
+This argument is `intent(in)`. 
+Transformed data to invert.
+
+`n`: Shall be an `integer` scalar.
+This argument is `intent(in)` and `optional`.  
+Defines the length of the Fourier transform. If `n` is not specified (the default) then `n = size(x)`. If `n <= size(x)`, `x` is truncated, if `n > size(x)`, `x` is zero-padded.
+
+#### Return value
+
+Returns a `real` and rank-1 array, the inverse Discrete-Cosine Transform (iDCT) of `x`.
+
+#### Example
+
+```fortran
+program demo_idct
+    use fftpack, only: dct, idct
+    real(kind=8) :: x(4) = [1, 2, 3, 4]
+    print *, idct(dct(x))/(2*(4-1))   !! (normalized):   [1.0, 2.0, 3.0, 4.0]
+    print *, idct(idct(x))/(2*(4-1))  !! (normalized):   [1.0, 2.0, 3.0, 4.0]
+    print *, idct(dct(x), 3)          !! (unnormalized): [7.0, 15.0, 23.0]
+end program demo_idct
+```
+
 
 ## Utility functions
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -72,6 +72,16 @@ name = "fftpack_iqct"
 source-dir = "test"
 main = "test_fftpack_iqct.f90"
 
+[[test]]
+name = "fftpack_dcost"
+source-dir = "test"
+main = "test_fftpack_dcost.f90"
+
+[[test]]
+name = "fftpack_dct"
+source-dir = "test"
+main = "test_fftpack_dct.f90"
+
 # `fftpack` utility routines
 [[test]]
 name = "fftpack_fftshift"

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,7 +58,8 @@ SRCF90 = \
 	fftpack_fftshift.f90\
 	fftpack_ifftshift.f90\
 	fftpack_qct.f90\
-	fftpack_iqct.f90
+	fftpack_iqct.f90\
+	fftpack_dct.f90
 
 OBJF := $(SRCF:.f=.o)
 OBJF90 := $(SRCF90:.f90=.o)
@@ -81,5 +82,6 @@ fftpack_rfft.o: fftpack.o
 fftpack_irfft.o: fftpack.o
 fftpack_qct.o: fftpack.o
 fftpack_iqct.o: fftpack.o
+fftpack_dct.o: fftpack.o
 fftpack_fftshift.o: fftpack.o
 fftpack_ifftshift.o: fftpack.o

--- a/src/fftpack.f90
+++ b/src/fftpack.f90
@@ -16,6 +16,9 @@ module fftpack
     public :: dcosqi, dcosqf, dcosqb
     public :: qct, iqct
 
+    public :: dcosti, dcost
+    public :: dct, idct
+
     interface
 
         !> Version: experimental
@@ -150,6 +153,26 @@ module fftpack
             real(kind=dp), intent(in) :: wsave(*)
         end subroutine dcosqb
 
+        !> Version: experimental
+        !>
+        !> Initialize `dcost`. ([Specification](../page/specs/fftpack.html#dcosti))
+        pure subroutine dcosti(n, wsave)
+            import dp
+            integer, intent(in) :: n
+            real(kind=dp), intent(out) :: wsave(*)
+        end subroutine dcosti
+
+        !> Version: experimental
+        !>
+        !> Discrete fourier cosine transform of an even sequence.
+        !> ([Specification](../page/specs/fftpack.html#dcost))
+        pure subroutine dcost(n, x, wsave)
+            import dp
+            integer, intent(in) :: n
+            real(kind=dp), intent(inout) :: x(*)
+            real(kind=dp), intent(in) :: wsave(*)
+        end subroutine dcost
+
     end interface
 
     !> Version: experimental
@@ -223,6 +246,26 @@ module fftpack
             real(kind=dp), allocatable :: result(:)
         end function iqct_dp
     end interface iqct
+
+    !> Version: experimental
+    !>
+    !> Discrete fourier cosine (forward) transform of an even sequence.
+    !> ([Specification](../page/specs/fftpack.html#dct))
+    interface dct
+        pure module function dct_dp(x, n) result(result)
+            real(kind=dp), intent(in) :: x(:)
+            integer, intent(in), optional :: n
+            real(kind=dp), allocatable :: result(:)
+        end function dct_dp
+    end interface dct
+
+    !> Version: experimental
+    !>
+    !> Discrete fourier cosine (backward) transform of an even sequence.
+    !> ([Specification](../page/specs/fftpack.html#idct))
+    interface idct
+        module procedure :: dct_dp
+    end interface idct
 
     !> Version: experimental
     !>

--- a/src/fftpack_dct.f90
+++ b/src/fftpack_dct.f90
@@ -1,0 +1,36 @@
+submodule(fftpack) fftpack_dct
+
+contains
+
+    !> Discrete fourier cosine transform of an even sequence.
+    pure module function dct_dp(x, n) result(result)
+        real(kind=dp), intent(in) :: x(:)
+        integer, intent(in), optional :: n
+        real(kind=dp), allocatable :: result(:)
+
+        integer :: lenseq, lensav, i
+        real(kind=dp), allocatable :: wsave(:)
+
+        if (present(n)) then
+            lenseq = n
+            if (lenseq <= size(x)) then
+                result = x(:lenseq)
+            else if (lenseq > size(x)) then
+                result = [x, (0.0_dp, i=1, lenseq - size(x))]
+            end if
+        else
+            lenseq = size(x)
+            result = x
+        end if
+
+        !> Initialize FFT
+        lensav = 3*lenseq + 15
+        allocate (wsave(lensav))
+        call dcosti(lenseq, wsave)
+
+        !> Discrete fourier cosine transformation
+        call dcost(lenseq, result, wsave)
+
+    end function dct_dp
+
+end submodule fftpack_dct

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,9 @@ all: tstfft \
 	fftpack_dzfft \
 	fftpack_dcosq \
 	fftpack_qct \
-	fftpack_iqct
+	fftpack_iqct \
+	fftpack_dcost \
+	fftpack_dct
 
 # Orginal test
 tstfft: tstfft.o
@@ -47,6 +49,14 @@ fftpack_qct: test_fftpack_qct.f90
 fftpack_iqct: test_fftpack_iqct.f90
 	$(FC) $(FFLAGS) $< -L../src -l$(LIB) -I../src -o $@.x
 	./fftpack_iqct.x
+
+fftpack_dcost: test_fftpack_dcost.f90
+	$(FC) $(FFLAGS) $< -L../src -l$(LIB) -I../src -o $@.x
+	./fftpack_dcost.x
+
+fftpack_dct: test_fftpack_dct.f90
+	$(FC) $(FFLAGS) $< -L../src -l$(LIB) -I../src -o $@.x
+	./fftpack_dct.x
 
 # `fftpack` utility routines
 fftpack_fftshift: test_fftpack_fftshift.f90

--- a/test/test_fftpack_dcosq.f90
+++ b/test/test_fftpack_dcosq.f90
@@ -22,7 +22,7 @@ contains
         call dcosqf(4, x, w)
         call check(sum(abs(x - [11.999626276085150_dp, -9.1029432177492193_dp, &
                                 2.6176618435106480_dp, -1.5143449018465791_dp])) < eps, msg="`dcosqf` failed.")
-        call dcosqb(4, x, w)    !!
+        call dcosqb(4, x, w)
         call check(sum(abs(x/(4.0_dp*4.0_dp) - [real(kind=dp) :: 1, 2, 3, 4])) < eps, msg="`dcosqb` failed.")
 
     end subroutine test_fftpack_dcosq_real

--- a/test/test_fftpack_dcost.f90
+++ b/test/test_fftpack_dcost.f90
@@ -1,0 +1,30 @@
+program tester
+
+    call test_fftpack_dcost_real
+    print *, "All tests in `test_fftpack_dcost` passed."
+
+contains
+
+    subroutine check(condition, msg)
+        logical, intent(in) :: condition
+        character(*), intent(in) :: msg
+        if (.not. condition) error stop msg
+    end subroutine check
+
+    subroutine test_fftpack_dcost_real
+        use fftpack, only: dcosti, dcost
+        use iso_fortran_env, only: dp => real64
+        real(kind=dp) :: w(3*4 + 15)
+        real(kind=dp) :: x(4) = [1, 2, 3, 4]
+        real(kind=dp) :: eps = 1.0e-10_dp
+
+        call dcosti(4, w)
+        call dcost(4, x, w)
+        call check(all(x == [real(kind=dp) :: 15, -4, 0, -1.0000000000000009_dp]), msg="`dcosti` failed.")
+
+        call dcost(4, x, w)
+        call check(all(x/(2.0_dp*(4.0_dp - 1.0_dp)) == [real(kind=dp) :: 1, 2, 3, 4]), msg="`dcost` failed.")
+
+    end subroutine test_fftpack_dcost_real
+
+end program tester

--- a/test/test_fftpack_dct.f90
+++ b/test/test_fftpack_dct.f90
@@ -1,0 +1,43 @@
+program tester
+
+    call test_fftpack_dct()
+    call test_fftpack_idct()
+    print *, "All tests in `test_fftpack_dct` passed."
+
+contains
+
+    subroutine check(condition, msg)
+        logical, intent(in) :: condition
+        character(*), intent(in) :: msg
+        if (.not. condition) error stop msg
+    end subroutine check
+
+    subroutine test_fftpack_dct
+        use fftpack, only: dct
+        use iso_fortran_env, only: dp => real64
+
+        real(kind=dp) :: x(3) = [9, -9, 3]
+
+        call check(all(dct(x, 2) == [real(kind=dp) :: 0, 18]), msg="`dct(x, 2)` failed.")
+        call check(all(dct(x, 3) == dct(x)), msg="`dct(x, 3)` failed.")
+        call check(all(dct(x, 4) == [real(kind=dp) :: -3, -3.0000000000000036_dp, 15, 33]), msg="`dct(x, 4)` failed.")
+
+    end subroutine test_fftpack_dct
+
+    subroutine test_fftpack_idct
+        use fftpack, only: dct, idct
+        use iso_fortran_env, only: dp => real64
+        real(kind=dp) :: eps = 1.0e-10_dp
+        real(kind=dp) :: x(4) = [1, 2, 3, 4]
+
+        call check(all(idct(dct(x))/(2.0_dp*(4.0_dp - 1.0_dp)) == [real(kind=dp) :: 1, 2, 3, 4]), &
+                   msg="`idct(dct(x))/(2.0_dp*(4.0_dp-1.0_dp))` failed.")
+        call check(all(idct(dct(x), 2)/(2.0_dp*(2.0_dp - 1.0_dp)) == [real(kind=dp) :: 5.5, 9.5]), &
+                   msg="`idct(dct(x), 2)/(2.0_dp*(2.0_dp-1.0_dp))` failed.")
+        call check(all(idct(dct(x, 2), 4)/(2.0_dp*(4.0_dp - 1.0_dp)) == &
+                   [0.16666666666666666_dp, 0.33333333333333331_dp, 0.66666666666666663_dp, 0.83333333333333315_dp]), &
+                   msg="`idct(dct(x, 2), 4)/(2.0_dp*(4.0_dp-1.0_dp))` failed.")
+
+    end subroutine test_fftpack_idct
+
+end program tester


### PR DESCRIPTION
- [x] add `(i)dct/dcosti/dcost` interfaces.
- [x] add `actions status ` in readme.md.
- [x] correct typos: pure `subroutine`.

#### Description
Discrete fourier cosine transform of an even sequence.
In order to maintain consistent usage like `fft/ifft`, `idct` is provided. (see https://github.com/fortran-lang/fftpack/pull/11#discussion_r694446752)
