### PR TITLE
Changed dp => real64 to dp = kind(1.0d0)

### DIFF
--- a/src/fftpack.f90
+++ b/src/fftpack.f90
@@ -1,8 +1,8 @@
 module fftpack
 
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     implicit none
     private
+    integer, parameter :: dp = kind(1.0d0)
 
     public :: zffti, zfftf, zfftb
     public :: fft, ifft

--- a/src/fftpack.f90
+++ b/src/fftpack.f90
@@ -4,6 +4,7 @@ module fftpack
     private
     integer, parameter :: dp = kind(1.0d0)
 
+    public :: dp
     public :: zffti, zfftf, zfftb
     public :: fft, ifft
     public :: fftshift, ifftshift

--- a/test/test_fftpack_dcosq.f90
+++ b/test/test_fftpack_dcosq.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_dcosq_real
         use fftpack, only: dcosqi, dcosqf, dcosqb
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
         real(kind=dp) :: w(3*4 + 15)
         real(kind=dp) :: x(4) = [1, 2, 3, 4]
         real(kind=dp) :: eps = 1.0e-10_dp

--- a/test/test_fftpack_dcosq.f90
+++ b/test/test_fftpack_dcosq.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_dcosq_real
-        use fftpack, only: dcosqi, dcosqf, dcosqb
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: dcosqi, dcosqf, dcosqb, dp
         real(kind=dp) :: w(3*4 + 15)
         real(kind=dp) :: x(4) = [1, 2, 3, 4]
         real(kind=dp) :: eps = 1.0e-10_dp

--- a/test/test_fftpack_dfft.f90
+++ b/test/test_fftpack_dfft.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_dfft()
         use fftpack, only: dffti, dfftf, dfftb
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
 
         real(kind=dp) :: x(4)
         real(kind=dp) :: w(31)

--- a/test/test_fftpack_dfft.f90
+++ b/test/test_fftpack_dfft.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_dfft()
-        use fftpack, only: dffti, dfftf, dfftb
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: dffti, dfftf, dfftb, dp
 
         real(kind=dp) :: x(4)
         real(kind=dp) :: w(31)

--- a/test/test_fftpack_dzfft.f90
+++ b/test/test_fftpack_dzfft.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_dzfft
-        use fftpack, only: dzffti, dzfftf, dzfftb
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: dzffti, dzfftf, dzfftb, dp
 
         real(kind=dp) :: x(4) = [1, 2, 3, 4]
         real(kind=dp) :: w(3*4 + 15)

--- a/test/test_fftpack_dzfft.f90
+++ b/test/test_fftpack_dzfft.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_dzfft
         use fftpack, only: dzffti, dzfftf, dzfftb
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
 
         real(kind=dp) :: x(4) = [1, 2, 3, 4]
         real(kind=dp) :: w(3*4 + 15)

--- a/test/test_fftpack_fft.f90
+++ b/test/test_fftpack_fft.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_fft
         use fftpack, only: fft
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
         real(kind=dp) :: eps = 1.0e-10_dp
 
         complex(kind=dp) :: x(3) = [1.0_dp, 2.0_dp, 3.0_dp]

--- a/test/test_fftpack_fft.f90
+++ b/test/test_fftpack_fft.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_fft
-        use fftpack, only: fft
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: fft, dp
         real(kind=dp) :: eps = 1.0e-10_dp
 
         complex(kind=dp) :: x(3) = [1.0_dp, 2.0_dp, 3.0_dp]

--- a/test/test_fftpack_fftshift.f90
+++ b/test/test_fftpack_fftshift.f90
@@ -13,8 +13,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_fftshift_complex
-        use fftpack, only: fftshift
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: fftshift, dp
 
         complex(kind=dp) :: xeven(4) = [1, 2, 3, 4]
         complex(kind=dp) :: xodd(5) = [1, 2, 3, 4, 5]
@@ -27,8 +26,7 @@ contains
     end subroutine test_fftpack_fftshift_complex
 
     subroutine test_fftpack_fftshift_real
-        use fftpack, only: fftshift
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: fftshift, dp
 
         real(kind=dp) :: xeven(4) = [1, 2, 3, 4]
         real(kind=dp) :: xodd(5) = [1, 2, 3, 4, 5]

--- a/test/test_fftpack_fftshift.f90
+++ b/test/test_fftpack_fftshift.f90
@@ -14,7 +14,7 @@ contains
 
     subroutine test_fftpack_fftshift_complex
         use fftpack, only: fftshift
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
 
         complex(kind=dp) :: xeven(4) = [1, 2, 3, 4]
         complex(kind=dp) :: xodd(5) = [1, 2, 3, 4, 5]
@@ -28,7 +28,7 @@ contains
 
     subroutine test_fftpack_fftshift_real
         use fftpack, only: fftshift
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
 
         real(kind=dp) :: xeven(4) = [1, 2, 3, 4]
         real(kind=dp) :: xodd(5) = [1, 2, 3, 4, 5]

--- a/test/test_fftpack_ifft.f90
+++ b/test/test_fftpack_ifft.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_ifft
         use fftpack, only: fft, ifft
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
         real(kind=dp) :: eps = 1.0e-10_dp
 
         complex(kind=dp) :: x(4) = [1, 2, 3, 4]

--- a/test/test_fftpack_ifft.f90
+++ b/test/test_fftpack_ifft.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_ifft
-        use fftpack, only: fft, ifft
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: fft, ifft, dp
         real(kind=dp) :: eps = 1.0e-10_dp
 
         complex(kind=dp) :: x(4) = [1, 2, 3, 4]

--- a/test/test_fftpack_ifftshift.f90
+++ b/test/test_fftpack_ifftshift.f90
@@ -14,7 +14,7 @@ contains
 
     subroutine test_fftpack_ifftshift_complex
         use fftpack, only: ifftshift
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
         integer :: i
 
         complex(kind=dp) :: xeven(4) = [3, 4, 1, 2]
@@ -29,7 +29,7 @@ contains
 
     subroutine test_fftpack_ifftshift_real
         use fftpack, only: ifftshift
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
         integer :: i
 
         real(kind=dp) :: xeven(4) = [3, 4, 1, 2]

--- a/test/test_fftpack_ifftshift.f90
+++ b/test/test_fftpack_ifftshift.f90
@@ -13,8 +13,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_ifftshift_complex
-        use fftpack, only: ifftshift
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: ifftshift, dp
         integer :: i
 
         complex(kind=dp) :: xeven(4) = [3, 4, 1, 2]
@@ -28,8 +27,7 @@ contains
     end subroutine test_fftpack_ifftshift_complex
 
     subroutine test_fftpack_ifftshift_real
-        use fftpack, only: ifftshift
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: ifftshift, dp
         integer :: i
 
         real(kind=dp) :: xeven(4) = [3, 4, 1, 2]

--- a/test/test_fftpack_iqct.f90
+++ b/test/test_fftpack_iqct.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_iqct
-        use fftpack, only: qct, iqct
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: qct, iqct, dp
         real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(4) = [1, 2, 3, 4]

--- a/test/test_fftpack_iqct.f90
+++ b/test/test_fftpack_iqct.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_iqct
         use fftpack, only: qct, iqct
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
         real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(4) = [1, 2, 3, 4]

--- a/test/test_fftpack_irfft.f90
+++ b/test/test_fftpack_irfft.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_irfft
         use fftpack, only: rfft, irfft
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
         real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(4) = [1, 2, 3, 4]

--- a/test/test_fftpack_irfft.f90
+++ b/test/test_fftpack_irfft.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_irfft
-        use fftpack, only: rfft, irfft
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: rfft, irfft, dp
         real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(4) = [1, 2, 3, 4]

--- a/test/test_fftpack_qct.f90
+++ b/test/test_fftpack_qct.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_qct
-        use fftpack, only: qct
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: qct, dp
         real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(3) = [9, -9, 3]

--- a/test/test_fftpack_qct.f90
+++ b/test/test_fftpack_qct.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_qct
         use fftpack, only: qct
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
         real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(3) = [9, -9, 3]

--- a/test/test_fftpack_rfft.f90
+++ b/test/test_fftpack_rfft.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_rfft
         use fftpack, only: rfft
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
         real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(3) = [9, -9, 3]

--- a/test/test_fftpack_rfft.f90
+++ b/test/test_fftpack_rfft.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_rfft
-        use fftpack, only: rfft
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: rfft, dp
         real(kind=dp) :: eps = 1.0e-10_dp
 
         real(kind=dp) :: x(3) = [9, -9, 3]

--- a/test/test_fftpack_zfft.f90
+++ b/test/test_fftpack_zfft.f90
@@ -13,7 +13,7 @@ contains
 
     subroutine test_fftpack_zfft()
         use fftpack, only: zffti, zfftf, zfftb
-        use iso_fortran_env, only: dp => real64
+        integer,parameter :: dp = kind(1.0d0)
 
         complex(kind=dp) :: x(4) = [1, 2, 3, 4]
         real(kind=dp) :: w(31)

--- a/test/test_fftpack_zfft.f90
+++ b/test/test_fftpack_zfft.f90
@@ -12,8 +12,7 @@ contains
     end subroutine check
 
     subroutine test_fftpack_zfft()
-        use fftpack, only: zffti, zfftf, zfftb
-        integer,parameter :: dp = kind(1.0d0)
+        use fftpack, only: zffti, zfftf, zfftb, dp
 
         complex(kind=dp) :: x(4) = [1, 2, 3, 4]
         real(kind=dp) :: w(31)


### PR DESCRIPTION
Since the original FFTPACK code uses "double precision", it's best to let `dp = kind(1.0d0)`, rather than using `dp => real64`. It's unlikely, but possible that there might be a platform/compiler where the standard double precision kind and real64 are not the same thing.