### PR TITLE
Update the outdated CI environment configuration

### DIFF
--- a/.github/workflows/doc-deployment.yml
+++ b/.github/workflows/doc-deployment.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: '3.x'
 
     - name: Install dependencies
-      run: pip install -v ford==6.1.5
+      run: pip install -v ford==6.1.17
 
     - name: Build Documentation
       run: ford API-doc-FORD-file.md

--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -3,23 +3,19 @@ name: fpm
 on: [push, pull_request]
 
 jobs:
-  build:
+  gcc-build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-11]
         gcc_v: [10] # Version of GFortran we want to use.
         include:
         - os: ubuntu-latest
           os-arch: linux-x86_64
 
-        - os: macos-latest
+        - os: macos-11
           os-arch: macos-x86_64
-
-        - os: windows-latest
-          os-arch: windows-x86_64
-            # Windows GFortran Version: 8.1
 
     env:
       FC: gfortran
@@ -35,6 +31,7 @@ jobs:
         ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
         which gfortran-${GCC_V}
         which gfortran
+
     - name: Install GFortran Linux
       if: contains(matrix.os, 'ubuntu')
       run: |
@@ -45,7 +42,7 @@ jobs:
     - name: Install fpm
       uses: fortran-lang/setup-fpm@v3
       with:
-        fpm-version: 'v0.5.0'
+        fpm-version: 'v0.7.0'
 
     - name: Build fftpack
       run: |
@@ -57,3 +54,29 @@ jobs:
         gfortran --version
         fpm test
 
+  msys2-build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          path-type: inherit
+          install: |
+            mingw-w64-x86_64-gcc-fortran
+            mingw-w64-x86_64-fpm
+
+      - name: fpm build
+        run: |
+          gfortran --version
+          fpm --version
+          fpm build
+
+      - name: fpm test
+        run: |
+          fpm test


### PR DESCRIPTION
### Description

- [x] Update the `ford` version to the latest version, `6.1.17`;
- [x] set `macOS` version `11`;
- [x] Uses the `msys2` environment as the `Windows` test environment;
- [x] Updates the `fpm` version to `0.7.0`.