### PR TITLE
Remove dynamic memory allocations in shift procedures

### DIFF
--- a/src/fftpack_fftshift.f90
+++ b/src/fftpack_fftshift.f90
@@ -5,7 +5,7 @@ contains
     !> Shifts zero-frequency component to center of spectrum for `complex` type.
     pure module function fftshift_crk(x) result(result)
         complex(kind=rk), intent(in) :: x(:)
-        complex(kind=rk), allocatable :: result(:)
+        complex(kind=rk), dimension(size(x)) :: result
 
         result = cshift(x, shift=-floor(0.5_rk*size(x)))
 
@@ -14,7 +14,7 @@ contains
     !> Shifts zero-frequency component to center of spectrum for `real` type.
     pure module function fftshift_rrk(x) result(result)
         real(kind=rk), intent(in) :: x(:)
-        real(kind=rk), allocatable :: result(:)
+        real(kind=rk), dimension(size(x)) :: result
 
         result = cshift(x, shift=-floor(0.5_rk*size(x)))
 

--- a/src/fftpack_ifftshift.f90
+++ b/src/fftpack_ifftshift.f90
@@ -5,7 +5,7 @@ contains
     !> Shifts zero-frequency component to beginning of spectrum for `complex` type.
     pure module function ifftshift_crk(x) result(result)
         complex(kind=rk), intent(in) :: x(:)
-        complex(kind=rk), allocatable :: result(:)
+        complex(kind=rk), dimension(size(x)) :: result
 
         result = cshift(x, shift=-ceiling(0.5_rk*size(x)))
 
@@ -14,7 +14,7 @@ contains
     !> Shifts zero-frequency component to beginning of spectrum for `real` type.
     pure module function ifftshift_rrk(x) result(result)
         real(kind=rk), intent(in) :: x(:)
-        real(kind=rk), allocatable :: result(:)
+        real(kind=rk), dimension(size(x)) :: result
 
         result = cshift(x, shift=-ceiling(0.5_rk*size(x)))
 


### PR DESCRIPTION
Regarding the shift procedures `fftshift` and `ifftshift`, as far as I understand the output vector of the functions is always of the same size as the input vector, so there's no need to declare the output vector as `allocatable` and dynamically allocate memory during runtime.

The proposed changes simply remove the memory allocation and set the output vector to be of the same size as the input one.