### PR TITLE
Add benchmarks for zfft & dfft

### DIFF
--- a/example/bench01_zfft.f90
+++ b/example/bench01_zfft.f90
@@ -13,6 +13,7 @@ allocate(x(N), z(N), w(4*N+15))
 call random_number(x)
 z = x
 
+print *, "01: Benchmarking zfft"
 print *, "Initializing"
 call cpu_time(t1)
 call zffti(N, w)
@@ -38,4 +39,5 @@ print *, "Error: ", err
 print *, "Init time: ", time_init
 print *, "Forward time: ", time_forward
 print *, "Backward time: ", time_backward
+print *, ""
 end program

--- a/example/bench02_zfft.f90
+++ b/example/bench02_zfft.f90
@@ -1,0 +1,64 @@
+program main
+use fftpack, only: zffti, zfftf, zfftb, fft, ifft
+use fftpack_kind, only: rk
+
+implicit none
+integer, parameter :: N = 1024*135*77  !> (2**10)*(3**3)*5*7*11
+
+complex(rk), dimension(N) :: x, z
+real(rk), dimension(4*N+15) :: w
+real(rk) :: err, time_i, time_f, time_b, t1, t2
+
+call random_number(x%re)
+z = x
+
+print *, "02: Benchmarking zfft & fft"
+
+call cpu_time(t1)
+call zffti(N, w)
+call cpu_time(t2)
+time_i = t2-t1
+print *, "Initializing: done"
+
+call cpu_time(t1)
+call zfftf(N, z, w)
+call cpu_time(t2)
+time_f = t2-t1
+print *, "Forward: done"
+
+call cpu_time(t1)
+call zfftb(N, z, w)
+call cpu_time(t2)
+time_b = t2-t1
+print *, "Backward: done"
+print *, ""
+
+err = maxval(abs(x-real(z/N,rk)))
+print *, "--zfft"
+print *, "Error: ", err
+print *, "Init. time: ", time_i
+print *, "Forward time: ", time_f
+print *, "Backward time: ", time_b
+print *, ""
+
+print *, "Comparing to calls through fft"
+call cpu_time(t1)
+z = fft(x)
+call cpu_time(t2)
+time_f = t2-t1
+print *, "Init. & forward: done"
+
+call cpu_time(t1)
+z = ifft(z)
+call cpu_time(t2)
+time_b = t2-t1
+print *, "Backward: done"
+print *, ""
+
+err = maxval(abs(x-real(z/N,rk)))
+print *, "--fft"
+print *, "Error: ", err
+print *, "Init. & forward time: ", time_f
+print *, "Backward time: ", time_b
+print *, ""
+end program

--- a/example/bench02_zfft.f90
+++ b/example/bench02_zfft.f90
@@ -3,7 +3,7 @@ use fftpack, only: zffti, zfftf, zfftb, fft, ifft
 use fftpack_kind, only: rk
 
 implicit none
-integer, parameter :: N = 1024*135*77  !> (2**10)*(3**3)*5*7*11
+integer, parameter :: N = 1024*135*77  ! (2**10)*(3**3)*5*7*11
 
 complex(rk), dimension(N) :: x, z
 real(rk), dimension(4*N+15) :: w

--- a/example/bench03_dfft.f90
+++ b/example/bench03_dfft.f90
@@ -3,7 +3,7 @@ use fftpack, only: dffti, dfftf, dfftb, rfft, irfft
 use fftpack_kind, only: rk
 
 implicit none
-integer, parameter :: N = 1024*135*77  !> (2**10)*(3**3)*5*7*11
+integer, parameter :: N = 1024*135*77  ! (2**10)*(3**3)*5*7*11
 
 real(rk), dimension(N) :: x, y
 real(rk), dimension(2*N+15) :: w

--- a/example/bench03_dfft.f90
+++ b/example/bench03_dfft.f90
@@ -1,0 +1,64 @@
+program main
+use fftpack, only: dffti, dfftf, dfftb, rfft, irfft
+use fftpack_kind, only: rk
+
+implicit none
+integer, parameter :: N = 1024*135*77  !> (2**10)*(3**3)*5*7*11
+
+real(rk), dimension(N) :: x, y
+real(rk), dimension(2*N+15) :: w
+real(rk) :: err, time_i, time_f, time_b, t1, t2
+
+call random_number(x)
+y = x
+
+print *, "03: Benchmarking dfft & rfft"
+
+call cpu_time(t1)
+call dffti(N, w)
+call cpu_time(t2)
+time_i = t2-t1
+print *, "Initializing: done"
+
+call cpu_time(t1)
+call dfftf(N, y, w)
+call cpu_time(t2)
+time_f = t2-t1
+print *, "Forward: done"
+
+call cpu_time(t1)
+call dfftb(N, y, w)
+call cpu_time(t2)
+time_b = t2-t1
+print *, "Backward: done"
+print *, ""
+
+err = maxval(abs(x-y/N))
+print *, "--dfft"
+print *, "Error: ", err
+print *, "Init. time: ", time_i
+print *, "Forward time: ", time_f
+print *, "Backward time: ", time_b
+print *, ""
+
+print *, "Comparing to calls through rfft"
+call cpu_time(t1)
+y = rfft(x)
+call cpu_time(t2)
+time_f = t2-t1
+print *, "Init. & forward: done"
+
+call cpu_time(t1)
+y = irfft(y)
+call cpu_time(t2)
+time_b = t2-t1
+print *, "Backward: done"
+print *, ""
+
+err = maxval(abs(x-y/N))
+print *, "--rfft"
+print *, "Error: ", err
+print *, "Init. & forward time: ", time_f
+print *, "Backward time: ", time_b
+print *, ""
+end program


### PR DESCRIPTION
This PR adds: 
1. a 2nd benchmark for the `zfft` procedures, where they're also compared against calls through the `fft` interface; 
2. a benchmark for the `dfft` procedures, also comparing them against calls through the `rfft` interface. 

The added runs are very similar in approach to the one that existed already for the `zfft` procedures. 