### PR TITLE
Add test CI for Linux-ifort

### DIFF
--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -80,3 +80,48 @@ jobs:
       - name: fpm test
         run: |
           fpm test
+
+  intel-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    env:
+      FPM_FC: ifort
+      FC: ifort
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Add Intel repository (Linux)
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+
+    - name: Install Intel oneAPI compiler (Linux)
+      run: |
+        sudo apt-get install intel-oneapi-compiler-fortran
+
+    - name: Setup Intel oneAPI environment
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
+
+    - name: Install fpm
+      uses: fortran-lang/setup-fpm@v3
+      with:
+        fpm-version: 'v0.7.0'
+
+    - name: fpm build
+      run: |
+        ifort --version
+        fpm --version
+        fpm build --profile debug --flag "-warn nointerfaces"
+
+    - name: fpm test
+      run: |
+        fpm test --profile debug --flag "-warn nointerfaces"


### PR DESCRIPTION
## Description

OneAPI already has the fft algorithm in mkl, and the main purpose of adding the Intel compiler CI is to ensure that the code conforms to the Fortran standards.

In fact, when testing `fftpack` for usability with Intel compilers, I found some old programming paradigms:

<div align="center">
    <img src="https://user-images.githubusercontent.com/32035096/222663799-817e1716-d29b-4a5c-a92b-5b468463ef38.png" width="480"/>
</div>

Passing floating-point type (`Wsave(2*n+1:)`) to integer (`Ifac(*)`) might trigger a compiler interface check error.
