### PR TITLE
Updating CMake CI support for Linux & MacOS

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,31 +7,43 @@ on:
     branches: [ "main" ]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        fortran_compiler: [gfortran, ifort]
+        os: [ubuntu-latest, macos-latest] # issue with windows-latest & CMake with CMake not recognizing defined compilers
 
     steps:
+
+    - name: Setup IFORT
+      if: contains( matrix.fortran_compiler, 'ifort' )
+      uses: modflowpy/install-intelfortran-action@v1
+
+    - name: Setup GFORTRAN
+      if: contains( matrix.fortran_compiler, 'gfortran')
+      uses: awvwgk/setup-fortran@main
+      id: setup-fortran
+      with:
+        compiler: gcc
+        version: 12
+        
+      env:
+        FC: ${{ steps.setup-fortran.outputs.fc }}
+        CC: ${{ steps.setup-fortran.outputs.cc }}
+
     - uses: actions/checkout@v3
-
+    
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-
-    - name: Build
-      # Build your program with the given configuration
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=${{ env.CC }} -DCMAKE_Fortran_COMPILER=${{ env.FC }} -DBUILD_TESTING=TRUE
+      
+    - name: Build with CMake
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
+    - name: Test with CMake
       working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-


### PR DESCRIPTION
Updating CI support for gfortran & ifort on both Linux & MacOS.  Windows support is posing a few issues that need more work; however, I believe it's not this library or build script, but instead an issue with the awvwgk/setup-fortran library I'm calling or how I'm using it that is giving me issues with Windows.  Regardless, I'd like to get this update out there while I continue to work on the support for Windows.