### PR TITLE
remove unused include helper.cmake in tests 

### DIFF
--- a/dependencies/test-drive/CMakeLists.txt
+++ b/dependencies/test-drive/CMakeLists.txt
@@ -1,4 +1,3 @@
-# Get the macros and functions we'll need
 include(FetchContent)
 
 # If found, use the installed version; else, import the library

--- a/dependencies/test-drive/CMakeLists.txt
+++ b/dependencies/test-drive/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Get the macros and functions we'll need
-#include("${PROJECT_SOURCE_DIR}/cmake/helper.cmake")
 include(FetchContent)
 
 # If found, use the installed version; else, import the library

--- a/dependencies/test-drive/CMakeLists.txt
+++ b/dependencies/test-drive/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Get the macros and functions we'll need
-include("${PROJECT_SOURCE_DIR}/cmake/helper.cmake")
+#include("${PROJECT_SOURCE_DIR}/cmake/helper.cmake")
 include(FetchContent)
 
 # If found, use the installed version; else, import the library

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-include("${PROJECT_SOURCE_DIR}/cmake/helper.cmake")
-
 macro(build_tests testname)
     add_executable(${testname} ${ARGN})
     link_library(${testname} fftpack ${PROJECT_INCLUDE_DIR})


### PR DESCRIPTION
As far as i can tell, none of the functions or macros in in the helpers.cmake are used in the dependencies/test-drive/CMakeLists.txt file and test/CMakeLists.txt. Therefore, I have deleted this include statement since it is unnecessary.