### PR TITLE
Removed unnecessary include call in install/

### DIFF
--- a/install/CMakeLists.txt
+++ b/install/CMakeLists.txt
@@ -1,5 +1,3 @@
-# Get the macros and functions we'll need
-include("${PROJECT_SOURCE_DIR}/cmake/helper.cmake")
 include(CMakePackageConfigHelpers)
 
 # Install the library and necessary include files


### PR DESCRIPTION
`include("${PROJECT_SOURCE_DIR}/cmake/helper.cmake")` is called in project root CMakeLists.txt, so it is not necessary to have it in `install/` as well.